### PR TITLE
Working docker compose structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <div style="height: 50px; width: 100%"></div>
 
   <a>
-    <img src="https://github.com/ABlockOfficial/Valence/blob/main/assets/hero.svg" alt="Logo" width="320px">
+    <img src="https://github.com/ABlockOfficial/Valence/blob/main/assets/hero.svg" alt="Logo" width="150px">
   </a>
 
   <div style="height: 50px; width: 100%"></div>

--- a/README.md
+++ b/README.md
@@ -4,13 +4,9 @@
 <br />
 
 <div align="center">
-    <div style="height: 50px; width: 100%"></div>
-
   <a>
-    <img src="https://github.com/ABlockOfficial/Valence/blob/main/assets/hero.svg" alt="Logo" width="150px">
+    <img src="https://github.com/ABlockOfficial/Valence/blob/main/assets/hero.svg" alt="Logo" width="200px">
   </a>
-
-  <div style="height: 50px; width: 100%"></div>
 
   <h3>Valence</h3>
 

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,10 @@
 # This is a sample config TOML for Valence
 debug = false
 extern_port = 3030
-cache_url = "redis://localhost"
+cache_url = "redis://cache"
 cache_port = "6379"
 cache_password = ""
-db_url = "mongodb://mongo-db"
+db_url = "mongodb://db"
 db_port = "27017"
 db_password = ""
 body_limit = 4096

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     command: redis-server --save 20 1 --loglevel warning
     volumes:
       - cache:/data/cache
-    container_name: redis-cache
+    container_name: cache
   db:
     image: mongo
     restart: always
@@ -23,7 +23,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: example
     volumes:
       - db:/data/db
-    container_name: mongo-db
+    container_name: db
   valence:
     build: .
     image: valence

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ async fn main() {
     let db_addr = format!("{}:{}", config.db_url, config.db_port);
     let cuckoo_filter = Arc::new(Mutex::new(cuckoofilter::CuckooFilter::new()));
 
+    println!("Connecting to Redis at {}", cache_addr);
+    println!("Connecting to MongoDB at {}", db_addr);
+
     let cache_conn = construct_redis_conn(&cache_addr).await;
     let db_conn = construct_mongodb_conn(&db_addr).await;
 


### PR DESCRIPTION
## Description
`docker compose` isn't currently working off of `main` due to a mismatch in URL declarations for supplementary services (MongoDB and Redis). This will fix the bug by standardising the declaration in both the `docker-compose.yml` and `Dockerfile`

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [ ] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [ ] My commits have clear and descriptive messages.
